### PR TITLE
ci(workflows): update lint pr workflow to be reusable

### DIFF
--- a/.github/workflows/semantic.yml
+++ b/.github/workflows/semantic.yml
@@ -1,14 +1,7 @@
 name: "Lint PR"
 
 on:
-  pull_request_target:
-    types:
-      - opened
-      - edited
-      - synchronize
-
-permissions:
-  pull-requests: read
+  workflow_call:
 
 jobs:
   main:


### PR DESCRIPTION
Because

- fix missing `workflow_call` to make workflow reusable

This commit

- update `on` section to replace `pull_request_target` with `workflow_call`
