### PR TITLE
chore(issue template): add issue ownership checkbox and update titles

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,4 +1,4 @@
-name: 🐞 Bug report
+name: 🐞 Report Bug
 description: File a bug
 title: "[Bug] <title>"
 labels: ["bug", "need-triage"]
@@ -13,6 +13,13 @@ body:
       description: Please search to see if an issue already exists for the bug you encountered.
       options:
         - label: I have searched the existing issues
+          required: true
+  - type: checkboxes
+    attributes:
+      label: Are you willing to own the issue?
+      description: Please state whether you can implement this or not.
+      options:
+        - label: I can own this issue
           required: true
   - type: dropdown
     id: project

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,5 +1,5 @@
-name: ✨ Feature Request
-description: Suggest a feature
+name: ✨ Request Feature
+description: Request for a new feature
 title: "[Feature] <title>"
 labels: ["feature", "need-triage"]
 body:
@@ -13,6 +13,13 @@ body:
       description: Please search to see if an issue already exists for the feature you requested.
       options:
         - label: I have searched the existing issues
+          required: true
+  - type: checkboxes
+    attributes:
+      label: Are you willing to own the issue?
+      description: Please state whether you can implement this or not.
+      options:
+        - label: I can own this issue
           required: true
   - type: dropdown
     id: project

--- a/.github/ISSUE_TEMPLATE/improvement.yaml
+++ b/.github/ISSUE_TEMPLATE/improvement.yaml
@@ -1,4 +1,4 @@
-name: 🧹 Improvement report
+name: 🧹 Suggest Improvement
 description: Suggest an improvement
 title: "[Improvement] <title>"
 labels: ["improvement", "need-triage"]
@@ -13,6 +13,13 @@ body:
       description: Please search to see if an issue already exists for the improvement you suggested.
       options:
         - label: I have searched the existing issues
+          required: true
+  - type: checkboxes
+    attributes:
+      label: Are you willing to own the issue?
+      description: Please state whether you can implement this or not.
+      options:
+        - label: I can own this issue
           required: true
   - type: dropdown
     id: project

--- a/.github/ISSUE_TEMPLATE/tutorial_request.yaml
+++ b/.github/ISSUE_TEMPLATE/tutorial_request.yaml
@@ -1,5 +1,5 @@
-name: 📖 Tutorial Request
-description: Request a tutorial
+name: 📖 Request Tutorial
+description: Request a new tutorial
 title: "[Tutorial] <title>"
 labels: ["tutorial", "documentation", "need-triage"]
 body:
@@ -13,6 +13,13 @@ body:
       description: Please search to see if an issue already exists for the feature you requested.
       options:
         - label: I have searched the existing issues
+          required: true
+  - type: checkboxes
+    attributes:
+      label: Are you willing to own the issue?
+      description: Please state whether you can implement this or not.
+      options:
+        - label: I can own this issue
           required: true
   - type: textarea
     attributes:


### PR DESCRIPTION
Because

- inconsistency in title 
- add ownership confirmation

This commit

- update issue template title 
- add checkbox to indicate if issue author can own this issue
